### PR TITLE
Fix Sablier plugin: migrate to new module name

### DIFF
--- a/services/traefik/config/traefik.yml
+++ b/services/traefik/config/traefik.yml
@@ -37,8 +37,8 @@ providers:
 experimental:
   plugins:
     sablier:
-      moduleName: "github.com/acouvreur/sablier"
-      version: "v1.10.1"
+      moduleName: "github.com/sablierapp/sablier-traefik-plugin"
+      version: "v1.1.0"
 
 certificatesResolvers:
   cloudflare:


### PR DESCRIPTION
The old plugin (github.com/acouvreur/sablier v1.10.1) was removed from the Traefik plugin registry, causing a 500 error on download. Updated to the new repo (github.com/sablierapp/sablier-traefik-plugin v1.1.0).