### PR TITLE
Add media server stack to production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,22 +8,26 @@ Homelab Infrastructure as Code (IaC) project. Ansible manages a Docker Compose-b
 
 ## Common Commands
 
-All commands run from the repo root.
+All commands run from the repo root. **Always activate the venv first:**
+
+```bash
+source .venv/bin/activate
+```
 
 ```bash
 # Install required Ansible collections
 ansible-galaxy collection install -r ansible/collections/requirements.yml
 
 # Deploy all services (production)
-ansible-playbook -i ansible/inventory/production ansible/playbooks/deploy-services.yml --ask-vault-pass
+ansible-playbook -i ansible/inventory/production ansible/playbooks/deploy-services.yml --vault-password-file ~/.vault_pass.txt
 
 # Deploy specific services only
 ansible-playbook -i ansible/inventory/production ansible/playbooks/deploy-services.yml \
-  -e '{"docker_service_targets": ["traefik", "monitoring"]}' --ask-vault-pass
+  -e '{"docker_service_targets": ["traefik", "monitoring"]}' --vault-password-file ~/.vault_pass.txt
 
 # Force redeploy even when no files changed
 ansible-playbook -i ansible/inventory/production ansible/playbooks/deploy-services.yml \
-  -e '{"docker_service_targets": ["traefik"], "docker_service_force_recreate": true}' --ask-vault-pass
+  -e '{"docker_service_targets": ["traefik"], "docker_service_force_recreate": true}' --vault-password-file ~/.vault_pass.txt
 
 # System hardening
 ansible-playbook -i ansible/inventory/production ansible/playbooks/hardening.yml
@@ -33,7 +37,7 @@ ansible-playbook -i ansible/inventory/production ansible/playbooks/docker-setup.
 
 # Dry run / check mode
 ansible-playbook -i ansible/inventory/production ansible/playbooks/deploy-services.yml \
-  --check --diff --ask-vault-pass
+  --check --diff --vault-password-file ~/.vault_pass.txt
 
 # Syntax validation
 ansible-playbook ansible/playbooks/deploy-services.yml --syntax-check
@@ -42,7 +46,7 @@ ansible-playbook ansible/playbooks/deploy-services.yml --syntax-check
 ansible-vault edit ansible/inventory/production/group_vars/all/vault.yml
 ```
 
-Replace `production` with `staging` for the staging environment.
+Replace `production` with `staging` for the staging environment. Use `--ask-vault-pass` only in interactive terminals; prefer `--vault-password-file ~/.vault_pass.txt` for non-interactive runs.
 
 ## Architecture
 
@@ -86,7 +90,7 @@ There are three service source directories at the repo root:
 
 - **`services/`** — Production services. Used by the production inventory (default).
 - **`dev_services/`** — Staging/dev services. Used by the staging inventory via a `docker_service_source_root` override in `ansible/inventory/staging/group_vars/homelab.yml`.
-- **`od_services/`** — On-demand services (e.g. managed via Sablier for auto-start on HTTP request). Not deployed by the main `deploy-services.yml` playbook unless `docker_service_source_root` is pointed at it.
+- **`od_services/`** — On-demand services (managed via Sablier for auto-start on HTTP request). Not deployed by `deploy-services.yml` unless `docker_service_source_root` is explicitly pointed at it.
 
 The `docker_service` role discovers services from whichever directory `docker_service_source_root` points to. Production inherits the role default (`services/`); staging overrides it to `dev_services/`. Place dev-only services or modified versions of production services in `dev_services/`.
 
@@ -97,10 +101,42 @@ Each subdirectory under a source directory represents a deployable service conta
 1. Create `services/<service-name>/docker-compose.yml` (plus `config/` if needed).
 2. Add `<service-name>_network` to `docker_service_networks` in `ansible/inventory/production/group_vars/homelab.yml` (so the network is created before deployment).
 3. If the service needs secrets, add an entry under `docker_service_env_files.<service-name>` in the vault and add it to `docker_service_required_env` if it must not deploy without secrets.
+4. If the service joins multiple Docker networks, add `traefik.docker.network: "traefik_network"` to its Traefik labels — otherwise Traefik may pick the wrong network IP and fail to route traffic.
+
+### Traefik Integration
+
+Services expose themselves to Traefik via Docker container labels. Standard label set:
+
+```yaml
+labels:
+  traefik.enable: "true"
+  traefik.http.routers.<name>.entrypoints: "websecure"
+  traefik.http.routers.<name>.tls.certresolver: "cloudflare"
+  traefik.http.routers.<name>.rule: "Host(`<name>.prod.landingsnet.com`)"
+  traefik.http.services.<name>.loadbalancer.server.port: "<port>"
+  traefik.docker.network: "traefik_network"   # Required when container is on multiple networks
+```
+
+All production services use `*.prod.landingsnet.com`. The `traefik.docker.network` label is mandatory when a container belongs to more than one Docker network — without it Traefik may resolve an IP from the wrong network and be unable to reach the backend.
+
+### Homepage Dashboard Integration
+
+Homepage auto-discovers containers via Docker labels. Add these to any service that should appear on the dashboard:
+
+```yaml
+labels:
+  homepage.name: "Display Name"
+  homepage.description: "Short description"
+  homepage.icon: "icon-name.png"   # see https://github.com/walkxcode/dashboard-icons
+  homepage.group: "Group Name"      # must match a group defined in services/homepage/config/settings.yaml
+  homepage.href: "https://<name>.prod.landingsnet.com"
+```
+
+New groups must be added to `services/homepage/config/settings.yaml` under the `layout:` key before they will render.
 
 ### Networking
 
-Services communicate over shared Docker networks defined in `docker_service_networks` in `ansible/inventory/production/group_vars/homelab.yml`. The `docker_service` role ensures these networks exist before deployment. Traefik acts as the reverse proxy, routing via container labels. Sablier handles on-demand container lifecycle (auto-start on HTTP request).
+Services communicate over shared Docker networks defined in `docker_service_networks` in `ansible/inventory/production/group_vars/homelab.yml`. The `docker_service` role ensures these networks exist before deployment. All networks are declared `external: true` in compose files — Ansible creates them, not Compose. Traefik acts as the reverse proxy, routing via container labels. Sablier handles on-demand container lifecycle (auto-start on HTTP request) and is configured in the `traefik` service.
 
 ### Secret Management
 
@@ -111,7 +147,7 @@ Services communicate over shared Docker networks defined in `docker_service_netw
 
 ## Key Configuration
 
-- **SSH**: Non-standard port 1022, key-only auth, no root login
+- **SSH**: Non-standard port 1022, key-only auth, no root login. Production host `prod-vm1` (192.168.1.191) uses key `~/.ssh/prod-vm1.pem`.
 - **ansible.cfg**: Vault password file at `~/.vault_pass.txt`, YAML stdout callback, roles path set to `ansible/roles`
-- **Renovate** (`renovate.json`): Automated Docker image updates on weekends, grouped by service category
+- **Renovate** (`renovate.json`): Automated Docker image updates on weekends, grouped by service category. `apple-trans` and `twingate/connector` are excluded.
 - **Required Ansible collections**: `community.general`, `community.docker`

--- a/ansible/inventory/production/group_vars/homelab.yml
+++ b/ansible/inventory/production/group_vars/homelab.yml
@@ -56,4 +56,5 @@ docker_service_networks:
   - apple-trans_network
   - snipe-it_network
   - homepage_network
+  - media_server_network
 

--- a/ansible/inventory/production/hosts.ini
+++ b/ansible/inventory/production/hosts.ini
@@ -1,7 +1,4 @@
 [homelab]
-owl_cloud  ansible_host=192.168.1.10  ansible_port=1022
-# new_server is kept alongside owl_cloud during migration; remove owl_cloud once cutover is complete.
-# ansible_port starts at 22; update to 1022 after hardening playbook runs.
 prod-vm1 ansible_host=192.168.1.191 ansible_port=1022 ansible_ssh_private_key_file=~/.ssh/prod-vm1.pem  
 [homelab:vars]
 ansible_user=frulexi

--- a/dev_services/media_server/.env.example
+++ b/dev_services/media_server/.env.example
@@ -1,3 +1,0 @@
-PUID=1000
-PGID=1000
-TZ=Europe/Madrid

--- a/od_services/minecraft-bedrock/docker-compose.yml
+++ b/od_services/minecraft-bedrock/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   minecraft:
     container_name: minecraft-bedrock
-    image: itzg/minecraft-bedrock-server:2026.2.2  # The Docker image for the Bedrock server
+    image: itzg/minecraft-bedrock-server:2026.4.2  # The Docker image for the Bedrock server
     volumes:
       - ./data:/data  # Persistent volume for server 
     stdin_open: true  # Keep STDIN open

--- a/services/homepage/config/settings.yaml
+++ b/services/homepage/config/settings.yaml
@@ -31,3 +31,6 @@ layout:
   Apps:
     style: row
     columns: 2
+  Media:
+    style: row
+    columns: 4

--- a/services/media_server/.env.example
+++ b/services/media_server/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to ".env" and fill in real values. Do not commit actual .env files.
+
+# User/group IDs for file ownership (run: id $(whoami) to find your values)
+PUID=1000
+PGID=1000
+
+# Timezone (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+TZ=America/New_York

--- a/services/media_server/docker-compose.yml
+++ b/services/media_server/docker-compose.yml
@@ -19,8 +19,14 @@ services:
       traefik.enable: "true"
       traefik.http.routers.jellyfin.entrypoints: "websecure"
       traefik.http.routers.jellyfin.tls.certresolver: "cloudflare"
-      traefik.http.routers.jellyfin.rule: "Host(`jellyfin.dev.landingsnet.com`)"
+      traefik.http.routers.jellyfin.rule: "Host(`jellyfin.prod.landingsnet.com`)"
       traefik.http.services.jellyfin.loadbalancer.server.port: "8096"
+      traefik.docker.network: "traefik_network"
+      homepage.name: "Jellyfin"
+      homepage.description: "Media streaming server"
+      homepage.icon: "jellyfin.png"
+      homepage.group: "Media"
+      homepage.href: "https://jellyfin.prod.landingsnet.com"
     restart: unless-stopped
 
   sonarr:
@@ -43,8 +49,14 @@ services:
       traefik.enable: "true"
       traefik.http.routers.sonarr.entrypoints: "websecure"
       traefik.http.routers.sonarr.tls.certresolver: "cloudflare"
-      traefik.http.routers.sonarr.rule: "Host(`sonarr.dev.landingsnet.com`)"
+      traefik.http.routers.sonarr.rule: "Host(`sonarr.prod.landingsnet.com`)"
       traefik.http.services.sonarr.loadbalancer.server.port: "8989"
+      traefik.docker.network: "traefik_network"
+      homepage.name: "Sonarr"
+      homepage.description: "TV series management"
+      homepage.icon: "sonarr.png"
+      homepage.group: "Media"
+      homepage.href: "https://sonarr.prod.landingsnet.com"
     restart: unless-stopped
 
   radarr:
@@ -67,8 +79,14 @@ services:
       traefik.enable: "true"
       traefik.http.routers.radarr.entrypoints: "websecure"
       traefik.http.routers.radarr.tls.certresolver: "cloudflare"
-      traefik.http.routers.radarr.rule: "Host(`radarr.dev.landingsnet.com`)"
+      traefik.http.routers.radarr.rule: "Host(`radarr.prod.landingsnet.com`)"
       traefik.http.services.radarr.loadbalancer.server.port: "7878"
+      traefik.docker.network: "traefik_network"
+      homepage.name: "Radarr"
+      homepage.description: "Movie management"
+      homepage.icon: "radarr.png"
+      homepage.group: "Media"
+      homepage.href: "https://radarr.prod.landingsnet.com"
     restart: unless-stopped
 
   prowlarr:
@@ -89,8 +107,14 @@ services:
       traefik.enable: "true"
       traefik.http.routers.prowlarr.entrypoints: "websecure"
       traefik.http.routers.prowlarr.tls.certresolver: "cloudflare"
-      traefik.http.routers.prowlarr.rule: "Host(`prowlarr.dev.landingsnet.com`)"
+      traefik.http.routers.prowlarr.rule: "Host(`prowlarr.prod.landingsnet.com`)"
       traefik.http.services.prowlarr.loadbalancer.server.port: "9696"
+      traefik.docker.network: "traefik_network"
+      homepage.name: "Prowlarr"
+      homepage.description: "Indexer manager"
+      homepage.icon: "prowlarr.png"
+      homepage.group: "Media"
+      homepage.href: "https://prowlarr.prod.landingsnet.com"
     restart: unless-stopped
 
   jellyseerr:
@@ -109,8 +133,14 @@ services:
       traefik.enable: "true"
       traefik.http.routers.jellyseerr.entrypoints: "websecure"
       traefik.http.routers.jellyseerr.tls.certresolver: "cloudflare"
-      traefik.http.routers.jellyseerr.rule: "Host(`jellyseerr.dev.landingsnet.com`)"
+      traefik.http.routers.jellyseerr.rule: "Host(`jellyseerr.prod.landingsnet.com`)"
       traefik.http.services.jellyseerr.loadbalancer.server.port: "5055"
+      traefik.docker.network: "traefik_network"
+      homepage.name: "Jellyseerr"
+      homepage.description: "Media request management"
+      homepage.icon: "jellyseerr.png"
+      homepage.group: "Media"
+      homepage.href: "https://jellyseerr.prod.landingsnet.com"
     restart: unless-stopped
 
   bazarr:
@@ -133,8 +163,14 @@ services:
       traefik.enable: "true"
       traefik.http.routers.bazarr.entrypoints: "websecure"
       traefik.http.routers.bazarr.tls.certresolver: "cloudflare"
-      traefik.http.routers.bazarr.rule: "Host(`bazarr.dev.landingsnet.com`)"
+      traefik.http.routers.bazarr.rule: "Host(`bazarr.prod.landingsnet.com`)"
       traefik.http.services.bazarr.loadbalancer.server.port: "6767"
+      traefik.docker.network: "traefik_network"
+      homepage.name: "Bazarr"
+      homepage.description: "Subtitle management"
+      homepage.icon: "bazarr.png"
+      homepage.group: "Media"
+      homepage.href: "https://bazarr.prod.landingsnet.com"
     restart: unless-stopped
 
   qbittorrent:
@@ -158,8 +194,14 @@ services:
       traefik.enable: "true"
       traefik.http.routers.qbittorrent.entrypoints: "websecure"
       traefik.http.routers.qbittorrent.tls.certresolver: "cloudflare"
-      traefik.http.routers.qbittorrent.rule: "Host(`qbittorrent.dev.landingsnet.com`)"
+      traefik.http.routers.qbittorrent.rule: "Host(`qbittorrent.prod.landingsnet.com`)"
       traefik.http.services.qbittorrent.loadbalancer.server.port: "8080"
+      traefik.docker.network: "traefik_network"
+      homepage.name: "qBittorrent"
+      homepage.description: "Torrent client"
+      homepage.icon: "qbittorrent.png"
+      homepage.group: "Media"
+      homepage.href: "https://qbittorrent.prod.landingsnet.com"
     restart: unless-stopped
 
   sabnzbd:
@@ -181,8 +223,14 @@ services:
       traefik.enable: "true"
       traefik.http.routers.sabnzbd.entrypoints: "websecure"
       traefik.http.routers.sabnzbd.tls.certresolver: "cloudflare"
-      traefik.http.routers.sabnzbd.rule: "Host(`sabnzbd.dev.landingsnet.com`)"
+      traefik.http.routers.sabnzbd.rule: "Host(`sabnzbd.prod.landingsnet.com`)"
       traefik.http.services.sabnzbd.loadbalancer.server.port: "8080"
+      traefik.docker.network: "traefik_network"
+      homepage.name: "SABnzbd"
+      homepage.description: "Usenet downloader"
+      homepage.icon: "sabnzbd.png"
+      homepage.group: "Media"
+      homepage.href: "https://sabnzbd.prod.landingsnet.com"
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
- Move media_server from dev_services to services with prod.landingsnet.com domains
- Add traefik.docker.network label to all containers to fix multi-network routing
- Add homepage labels and Media group for dashboard auto-discovery
- Add media_server_network to production docker_service_networks
- Remove stale owl_cloud host from production inventory
- Update CLAUDE.md with Traefik multi-network gotcha, homepage label convention, and venv/vault-password-file guidance