### PR TITLE
Codify SABnzbd hostname whitelist via environment variable

### DIFF
--- a/services/media_server/docker-compose.yml
+++ b/services/media_server/docker-compose.yml
@@ -206,6 +206,7 @@ services:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
+      - SABNZBD__misc__host_whitelist=sabnzbd,sabnzbd.prod.landingsnet.com,
     volumes:
       - sabnzbd_config:/config
       - /opt/homelab/media:/data


### PR DESCRIPTION
Adds SABNZBD__misc__host_whitelist so the whitelist survives volume recreation. Includes both the container hostname (for Sonarr/Radarr internal API calls) and the public domain (for browser access via Traefik).